### PR TITLE
Fix scoreboard collide

### DIFF
--- a/.github/workflows/assemble.yaml
+++ b/.github/workflows/assemble.yaml
@@ -36,7 +36,6 @@ jobs:
           tag: current-main
           release_name: current-main
           body: "binary files for current state of main branch"
-          prerelease: true
           overwrite: true
           file_glob: true
       - name: upload binaries to created release

--- a/cart.asm
+++ b/cart.asm
@@ -396,17 +396,17 @@ P0xDone:
 
 ;;; P0 y bounds checking
 	lda P0y
-	cmp #8
+	cmp #10
 	beq P0yLow
-	cmp #PLAYAREALINES
+	cmp #PLAYAREALINES+1
 	beq P0yHigh
 	jmp P0yDone
 P0yLow:
-	lda #9
+	lda #11
 	sta P0y
 	jmp P0yDone
 P0yHigh:
-	lda #PLAYAREALINES-1
+	lda #PLAYAREALINES
 	sta P0y
 P0yDone:
 	


### PR DESCRIPTION
closes #5 
This is kind of a hack.  The sprite is 9 lines (of which the last one is blank), so comparing with 9 and setting to 8 should be fine, but (i think due to timing issues on the left side of the screen) i had to make it 11 and 10 before it worked properly.

A real fix will come when fixing the sprite drawing timing issues.